### PR TITLE
Refactor/project struct

### DIFF
--- a/StarResonanceDpsAnalysis.WPF/App.xaml
+++ b/StarResonanceDpsAnalysis.WPF/App.xaml
@@ -13,11 +13,15 @@
                 <ResourceDictionary Source="pack://application:,,,/Styles/FooterStyles.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/TestThemeStyle.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/Classes.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/SeparatorStyle.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/CardControlStyle.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Converters/ConveterDictionary.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/AntControls.xaml" />
 
                 <!--  Load SortedDpsControl default style  -->
                 <ResourceDictionary Source="pack://application:,,,/Styles/SortedDpsControlStyle.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/DpsIndicatorControlStyle.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/ImageResourceDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/StarResonanceDpsAnalysis.WPF/Controls/CardControl.cs
+++ b/StarResonanceDpsAnalysis.WPF/Controls/CardControl.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace StarResonanceDpsAnalysis.WPF.Controls;
+
+public class CardControl : HeaderedContentControl
+{
+    static CardControl()
+    {
+        // Ensure the style lookup targets this control type
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(CardControl),
+            new FrameworkPropertyMetadata(typeof(CardControl)));
+    }
+}

--- a/StarResonanceDpsAnalysis.WPF/Settings/AppConfig.cs
+++ b/StarResonanceDpsAnalysis.WPF/Settings/AppConfig.cs
@@ -60,16 +60,16 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// - 仅在首次读取对应属性时，从 INI 取值并写入缓存；之后命中缓存避免重复 IO。
         /// </summary>
         // 网卡编号（可能用于网络数据抓取的网卡选择），null 表示尚未设置
-        private static int? _networkCard = null;
+        private int? _networkCard = null;
 
         // 窗体透明度（0.0~1.0），null 表示未设置
-        private static double? _transparency = null;
+        private double? _transparency = null;
 
         // 是否使用浅色模式（true 浅色 / false 深色），null 表示未设置
-        private static bool? _isLight = null;
+        private bool? _isLight = null;
 
         // 启动时的窗口状态（位置和大小），null 表示未设置
-        private static Rectangle? _startUpState = null;
+        private Rectangle? _startUpState = null;
 
         //// 鼠标穿透的快捷键（例如 Ctrl+Shift+...），null 表示未设置
         //private static Keys? _mouseThroughKey = null;
@@ -83,12 +83,12 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         //// 清空当前数据的快捷键，null 表示未设置
         //private static Keys? _clearDataKey = null;
 
-        private static string? _damageDisplayType = null;
+        private string? _damageDisplayType = null;
 
         /// <summary>
         /// DPS伤害类型显示
         /// </summary>
-        public static string DamageDisplayType
+        public string DamageDisplayType
         {
             get
             {
@@ -108,28 +108,18 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
             }
 
         }
-        /// <summary>
-        /// # 分类：外观/用户信息/业务参数（立即可用的公开字段）
-        /// - DpsColor：进度条或 DPS 相关 UI 颜色
-        /// - NickName：用户昵称（默认“未设置昵称”）
-        /// - Uid：用户 UID，默认 0
-        /// - CombatTimeClearDelaySeconds：战斗计时清除延迟秒数（默认 5 秒）
-        ///   用于 UI 或统计在战斗结束后延迟清除，避免过快闪烁。
-        /// </summary>
-        public static Color DpsColor = Color.FromArgb(0x22, 0x97, 0xF4);//进度条颜色
 
-        private static string? _nickName = null;
-        private static string? _profession = null;
-        private static long? _uid = null;//用户UID
-        private static int? _combatPower = null;//战斗力
-        public static int? _combatTimeClearDelaySeconds;//战斗计时清除延迟
-        public static int _clearPicture = 1;//是否过图清空记录
-        public static Color colorText = Color.Black;//文字颜色
+        private string? _nickName = null;
+        private string? _profession = null;
+        private long? _uid = null;//用户UID
+        private int? _combatPower = null;//战斗力
+        public int? _combatTimeClearDelaySeconds;//战斗计时清除延迟
+        public int _clearPicture = 1;//是否过图清空记录
 
         /// <summary>
         /// 是否过图清全程记录
         /// </summary>
-        public static int ClearPicture
+        public int ClearPicture
         {
             get
             {
@@ -149,7 +139,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
             }
         }
 
-        public static int CombatTimeClearDelaySeconds
+        public int CombatTimeClearDelaySeconds
         {
             get
             {
@@ -170,7 +160,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// <summary>
         /// 昵称
         /// </summary>
-        public static string NickName
+        public string NickName
         {
             get
             {
@@ -191,7 +181,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// <summary>
         /// 职业
         /// </summary>
-        public static string Profession
+        public string Profession
         {
             get
             {
@@ -211,7 +201,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// <summary>
         /// UID
         /// </summary>
-        public static long Uid
+        public  long Uid
         {
             get
             {
@@ -233,7 +223,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// <summary>
         /// 战力
         /// </summary>
-        public static int CombatPower
+        public int CombatPower
         {
             get
             {
@@ -261,7 +251,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// 设置流程：
         /// - 写入 INI 文件并更新缓存。
         /// </summary>
-        public static int NetworkCard
+        public int NetworkCard
         {
             get
             {
@@ -284,7 +274,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// UI 总体透明度百分比，默认 100（不透明）。
         /// 注意：此处未强制约束范围；调用方应确保 0-100 合法范围，或在使用处进行钳制。
         /// </summary>
-        public static double Transparency
+        public double Transparency
         {
             get
             {
@@ -307,7 +297,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// IsLight = true 表示浅色主题，false 表示深色主题。
         /// 读取时默认值 "1"（即浅色）。
         /// </summary>
-        public static bool IsLight
+        public bool IsLight
         {
             get
             {
@@ -328,7 +318,7 @@ namespace StarResonanceDpsAnalysis.WPF.Settings
         /// <summary>
         /// 启动位置
         /// </summary>
-        public static Rectangle? StartUpState
+        public Rectangle? StartUpState
         {
             get
             {

--- a/StarResonanceDpsAnalysis.WPF/Styles/AntControls.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/AntControls.xaml
@@ -1,0 +1,283 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!--  Ant Design - like brushes and metrics  -->
+    <Color x:Key="AntBorderColor">#FFD9D9D9</Color>
+    <Color x:Key="AntHoverColor">#FF40A9FF</Color>
+    <Color x:Key="AntPrimaryColor">#FF1890FF</Color>
+    <Color x:Key="AntBackgroundColor">#FFFFFFFF</Color>
+    <Color x:Key="AntDisabledColor">#FFF5F5F5</Color>
+
+    <SolidColorBrush x:Key="AntBorderBrush" Color="{StaticResource AntBorderColor}" />
+    <SolidColorBrush x:Key="AntHoverBrush" Color="{StaticResource AntHoverColor}" />
+    <SolidColorBrush x:Key="AntPrimaryBrush" Color="{StaticResource AntPrimaryColor}" />
+    <SolidColorBrush x:Key="AntBackgroundBrush" Color="{StaticResource AntBackgroundColor}" />
+    <SolidColorBrush x:Key="AntDisabledBrush" Color="{StaticResource AntDisabledColor}" />
+
+    <sys:Double x:Key="AntCornerRadiusValue">6</sys:Double>
+    <CornerRadius
+        x:Key="AntCornerRadius"
+        BottomLeft="{StaticResource AntCornerRadiusValue}"
+        BottomRight="{StaticResource AntCornerRadiusValue}"
+        TopLeft="{StaticResource AntCornerRadiusValue}"
+        TopRight="{StaticResource AntCornerRadiusValue}" />
+    <Thickness x:Key="AntControlPadding">6,4,6,4</Thickness>
+
+    <!-- Plain ToggleButton style (no hover visuals) -->
+    <Style x:Key="PlainToggleButton" TargetType="ToggleButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <ContentPresenter />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--  TextBox style  -->
+    <Style x:Key="AntTextBoxStyle" TargetType="TextBox">
+        <Setter Property="Background" Value="{StaticResource AntBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AntBorderBrush}" />
+        <Setter Property="Foreground" Value="Black" />
+        <Setter Property="Padding" Value="{StaticResource AntControlPadding}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border
+                        x:Name="Bd"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource AntCornerRadius}">
+                        <ScrollViewer x:Name="PART_ContentHost" Margin="0" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AntHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AntPrimaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource AntDisabledBrush}" />
+                            <Setter Property="Foreground" Value="#FFAAAAAA" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--  ComboBox style  -->
+    <Style x:Key="AntComboBoxStyle" TargetType="ComboBox">
+        <Setter Property="Background" Value="{StaticResource AntBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AntBorderBrush}" />
+        <Setter Property="Padding" Value="{StaticResource AntControlPadding}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <!--  Use a ToggleButton as the entire clickable area -->
+                        <ToggleButton
+                            x:Name="ToggleButton"
+                            Style="{StaticResource PlainToggleButton}"
+                            IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border
+                                        x:Name="Bd"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{StaticResource AntCornerRadius}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <ContentPresenter
+                                                Grid.Column="0"
+                                                x:Name="ContentSite"
+                                                Margin="8,2,6,2"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                Content="{Binding SelectionBoxItem, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                ContentTemplate="{Binding SelectionBoxItemTemplate, RelativeSource={RelativeSource AncestorType=ComboBox}}" />
+
+                                            <Path
+                                                Grid.Column="1"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Data="M 0 0 L 4 4 L 8 0 Z"
+                                                Fill="Black"
+                                                Margin="6,0,6,0" />
+                                        </Grid>
+                                    </Border>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+
+                        <!--  Popup aligned to left: width bound to ComboBox ActualWidth  -->
+                        <Popup
+                            x:Name="PART_Popup"
+                            AllowsTransparency="True"
+                            Focusable="False"
+                            HorizontalOffset="0"
+                            IsOpen="{TemplateBinding IsDropDownOpen}"
+                            Placement="Bottom"
+                            PopupAnimation="Fade">
+                            <Border
+                                Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                Padding="2"
+                                Background="{StaticResource AntBackgroundBrush}"
+                                BorderBrush="{StaticResource AntBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="{StaticResource AntCornerRadius}">
+                                <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter HorizontalAlignment="Stretch" />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasItems" Value="False">
+                            <Setter TargetName="PART_Popup" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="#FFAAAAAA" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ToggleButton" Property="BorderBrush" Value="{StaticResource AntHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="ToggleButton" Property="BorderBrush" Value="{StaticResource AntPrimaryBrush}" />
+                        </Trigger>
+                        <!--  Match Popup border width if width changes after open  -->
+                        <Trigger Property="IsDropDownOpen" Value="True">
+                            <Setter TargetName="PART_Popup" Property="HorizontalOffset" Value="0" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ComboBoxItem">
+        <Setter Property="Padding" Value="12,8" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="Bd" 
+                            Background="Transparent"
+                            Padding="{TemplateBinding Padding}"
+                            MinHeight="{TemplateBinding MinHeight}">
+                        <ContentPresenter 
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="#FFF0F5FF" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="#FFE6F7FF" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="#FFAAAAAA" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--  Slider style  -->
+    <Style x:Key="AntSliderStyle" TargetType="Slider">
+        <Setter Property="Height" Value="24" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid>
+                        <!-- Background track - changed to blue -->
+                        <Border
+                            Height="4"
+                            VerticalAlignment="Center"
+                            Background="{StaticResource AntPrimaryBrush}"
+                            CornerRadius="2" />
+                        <Track
+                            x:Name="PART_Track"
+                            IsDirectionReversed="{TemplateBinding IsDirectionReversed}"
+                            Maximum="{TemplateBinding Maximum}"
+                            Minimum="{TemplateBinding Minimum}"
+                            Value="{Binding Path=Value, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Command="Slider.DecreaseLarge">
+                                    <RepeatButton.Template>
+                                        <ControlTemplate TargetType="RepeatButton">
+                                            <!-- Empty template to remove hover rectangle -->
+                                            <Rectangle Fill="Transparent" />
+                                        </ControlTemplate>
+                                    </RepeatButton.Template>
+                                </RepeatButton>
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Command="Slider.IncreaseLarge">
+                                    <RepeatButton.Template>
+                                        <ControlTemplate TargetType="RepeatButton">
+                                            <!-- Empty template to remove hover rectangle -->
+                                            <Rectangle Fill="Transparent" />
+                                        </ControlTemplate>
+                                    </RepeatButton.Template>
+                                </RepeatButton>
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb
+                                    x:Name="Thumb"
+                                    Width="14"
+                                    Height="14"
+                                    Background="White"
+                                    BorderBrush="#FFCCCCCC"
+                                    BorderThickness="1">
+                                    <Thumb.Template>
+                                        <ControlTemplate TargetType="Thumb">
+                                            <Ellipse
+                                                Fill="White"
+                                                Stroke="#FFCCCCCC"
+                                                StrokeThickness="1" />
+                                        </ControlTemplate>
+                                    </Thumb.Template>
+                                </Thumb>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Thumb" Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Styles/BaseStyle.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/BaseStyle.xaml
@@ -1,4 +1,7 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:sys="clr-namespace:System;assembly=System.Runtime">
 
     <!--  引入 System.Double 类型（用于定义数值资源）  -->
     <sys:Double xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="MainCornerRadiusDouble">6</sys:Double>
@@ -50,9 +53,47 @@
             </Setter.Value>
         </Setter>
     </Style>
-
     <Style x:Key="SpliterBase" TargetType="Border">
         <Setter Property="Height" Value="1" />
         <Setter Property="Background" Value="#ECECEC" />
     </Style>
+
+    <Style x:Key="NormalTextBlockBaseStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="pack://application:,,,/Assets/Fonts/#HarmonyOS Sans SC" />
+    </Style>
+
+    <Style x:Key="CardBorderBaseStyle" TargetType="Border">
+        <Setter Property="Padding" Value="20" />
+        <Setter Property="Margin" Value="10" />
+        <Setter Property="Background" Value="#FFF" />
+        <Setter Property="CornerRadius" Value="{StaticResource MainCornerRadius}" />
+    </Style>
+
+    <Style
+        x:Key="CardHeaderBaseStyle"
+        BasedOn="{StaticResource NormalTextBlockBaseStyle}"
+        TargetType="TextBlock">
+        <Setter Property="Foreground" Value="#2297F4" />
+    </Style>
+    <Style
+        x:Key="CardHeaderMainTitleStyle"
+        BasedOn="{StaticResource CardHeaderBaseStyle}"
+        TargetType="TextBlock">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <Style
+        x:Key="CardHeaderSubTitleStyle"
+        BasedOn="{StaticResource CardHeaderBaseStyle}"
+        TargetType="TextBlock">
+        <Setter Property="FontSize" Value="9" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <sys:Double x:Key="CardHeaderHeight">26</sys:Double>
+
+    <!--  设置默认字体  -->
+    <Style BasedOn="{StaticResource NormalTextBlockBaseStyle}" TargetType="TextBlock" />
 </ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Styles/BaseStyle.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/BaseStyle.xaml
@@ -1,10 +1,10 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:sys="clr-namespace:System;assembly=System.Runtime">
+    xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <!--  引入 System.Double 类型（用于定义数值资源）  -->
-    <sys:Double xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="MainCornerRadiusDouble">6</sys:Double>
+    <sys:Double x:Key="MainCornerRadiusDouble">6</sys:Double>
 
     <!--  以 CornerRadius 资源形式定义圆角（四个角相同）  -->
     <CornerRadius x:Key="MainCornerRadius">6,6,6,6</CornerRadius>

--- a/StarResonanceDpsAnalysis.WPF/Styles/ButtonStyle.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/ButtonStyle.xaml
@@ -1,8 +1,10 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <!--  可被替换的资源（像 CSS 变量）  -->
     <FontFamily x:Key="IconButtonFontFamily">Segoe UI Symbol</FontFamily>
-    <sys:Double xmlns:sys="clr-namespace:System;assembly=mscorlib" x:Key="IconButtonFontSize">14</sys:Double>
+    <sys:Double x:Key="IconButtonFontSize">14</sys:Double>
 
     <!--  图标按钮样式（去掉焦点虚线 + 悬停阴影）  -->
     <Style x:Key="IconButtonStyle" TargetType="Button">
@@ -16,8 +18,22 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
+                    <ControlTemplate.Resources>
+                        <!-- DataTemplate for string content: creates a TextBlock that binds to the Button's FontFamily/FontSize -->
+                        <DataTemplate DataType="{x:Type sys:String}">
+                            <TextBlock Text="{Binding}"
+                                       FontFamily="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=FontFamily}"
+                                       FontSize="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=FontSize}"
+                                       TextAlignment="Center" />
+                        </DataTemplate>
+                    </ControlTemplate.Resources>
+
                     <Border Background="{TemplateBinding Background}">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        <!-- Let ContentPresenter use TemplateBindings; when Content is a string the DataTemplate above will be used and will apply local FontFamily/FontSize -->
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/StarResonanceDpsAnalysis.WPF/Styles/CardControlStyle.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/CardControlStyle.xaml
@@ -1,0 +1,48 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:StarResonanceDpsAnalysis.WPF.Controls"
+    xmlns:converters="clr-namespace:StarResonanceDpsAnalysis.WPF.Converters">
+
+    <Style x:Key="LeftDecorationStyle" TargetType="Border">
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="Background" Value="#2297F4" />
+        <Setter Property="Margin" Value="-20,-10,0,-10" />
+        <Setter Property="Width" Value="3" />
+    </Style>
+    <Style TargetType="controls:CardControl">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="controls:CardControl">
+                    <Border Style="{StaticResource CardBorderBaseStyle}">
+                        <StackPanel>
+                            <!--  Bind Content and ContentTemplate correctly for header  -->
+                            <Grid x:Name="PART_Header">
+                                <Border Height="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=Grid, AncestorLevel=1}}" Style="{StaticResource LeftDecorationStyle}" />
+                                <ContentPresenter Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" />
+                            </Grid>
+                            <!--  Header content separator  -->
+                            <Separator
+                                x:Name="PART_HeaderSeparator"
+                                Margin="0,0,0,20"
+                                Style="{StaticResource HorizontalSeparatorStyle}" />
+                            <!--  Content section  -->
+                            <ContentPresenter
+                                x:Name="PART_Content"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        </StackPanel>
+                    </Border>
+
+                    <ControlTemplate.Triggers>
+                        <!--  Hide header and separator if there's no header  -->
+                        <Trigger Property="Header" Value="{x:Null}">
+                            <Setter TargetName="PART_Header" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_HeaderSeparator" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Styles/ImageResourceDictionary.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/ImageResourceDictionary.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <BitmapImage x:Key="ImageOkHover" UriSource="pack://application:,,,/Assets/Images/ok_hover.png" />
+    <BitmapImage x:Key="ImageOkNormal" UriSource="pack://application:,,,/Assets/Images/ok_normal.png" />
+    <BitmapImage x:Key="ImageCancelHover" UriSource="pack://application:,,,/Assets/Images/cancel_hover.png" />
+    <BitmapImage x:Key="ImageCancelNormal" UriSource="pack://application:,,,/Assets/Images/cancel_normal.png" />
+    <BitmapImage x:Key="ImageCrown" UriSource="pack://application:,,,/Assets/Images/Crown.png" />
+</ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Styles/SeparatorStyle.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Styles/SeparatorStyle.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+
+    <Style x:Key="HorizontalSeparatorStyle" TargetType="{x:Type Separator}">
+        <Setter Property="Background" Value="#ECECEC" />
+        <Setter Property="Focusable" Value="false" />
+        <Setter Property="Height" Value="1" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Separator}">
+                    <Line
+                        Stretch="Fill"
+                        Stroke="{TemplateBinding Background}"
+                        StrokeEndLineCap="Square"
+                        StrokeStartLineCap="Square"
+                        StrokeThickness="{TemplateBinding Height}"
+                        X2="1" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Themes/Dark.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Themes/Dark.xaml
@@ -1,4 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Color x:Key="Test.TextColor">#00FF00</Color>
     <SolidColorBrush x:Key="TestTextSolidBrush" Color="{StaticResource Test.TextColor}" />
+    <Color x:Key="AccentColor">#2297F4</Color>
+    <SolidColorBrush x:Key="AccentSolidBrush" Color="{StaticResource AccentColor}" />
 </ResourceDictionary>

--- a/StarResonanceDpsAnalysis.WPF/Themes/Functions/ApplicationThemeManager.cs
+++ b/StarResonanceDpsAnalysis.WPF/Themes/Functions/ApplicationThemeManager.cs
@@ -6,9 +6,10 @@ namespace StarResonanceDpsAnalysis.WPF.Themes;
 public class ApplicationThemeManager
 {
     // internal const string LibraryNamespace = "StarResonanceDpsAnalysis.WPF";
-    internal const string LibraryNamespace = "";
+    internal const string LibraryNamespace = "StarResonanceDpsAnalysis.WPF";
 
-    internal const string ThemesDictionaryPath = "pack://application:,,,/Themes/";
+    // include assembly name and component segment so pack URIs resolve in designer
+    internal const string ThemesDictionaryPath = "pack://application:,,,/" + LibraryNamespace + ";component/Themes/";
     private readonly ResourceDictionaryManager _appDictionaries = new(LibraryNamespace);
     private ApplicationTheme _cachedApplicationTheme = ApplicationTheme.Unknown;
 

--- a/StarResonanceDpsAnalysis.WPF/Themes/Light.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Themes/Light.xaml
@@ -1,4 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Color x:Key="Test.TextColor">#FF0000</Color>
     <SolidColorBrush x:Key="TestTextSolidBrush" Color="{StaticResource Test.TextColor}" />
+    <Color x:Key="AccentColor">#2297F4</Color>
+    <SolidColorBrush x:Key="AccentSolidBrush" Color="{StaticResource AccentColor}" />
 </ResourceDictionary>


### PR DESCRIPTION
以下为Copilot生成

This pull request introduces several new resource dictionaries for styles and controls, adds a new `CardControl` custom control, and refactors the `AppConfig` class to use instance members and properties instead of static ones. The changes improve the maintainability and extensibility of the codebase, especially for application configuration and UI styling.

**UI and Styles Enhancements:**

* Added new resource dictionaries for various styles, including `SeparatorStyle.xaml`, `CardControlStyle.xaml`, `AntControls.xaml`, and `ImageResourceDictionary.xaml` to `App.xaml`, enabling the use of new and updated UI components and styles.
* Introduced a new custom control `CardControl` in `CardControl.cs`, which extends `HeaderedContentControl` and sets up its default style key for WPF styling.

**AppConfig Refactor:**

* Refactored the `AppConfig` class in `AppConfig.cs` by converting previously static fields and properties (such as `NetworkCard`, `Transparency`, `IsLight`, `StartUpState`, `DamageDisplayType`, `NickName`, `Profession`, `Uid`, `CombatPower`, `CombatTimeClearDelaySeconds`, and `ClearPicture`) to instance members and properties. This change allows for better encapsulation and potential future support for multiple configuration instances. [[1]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L63-R72) [[2]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L86-R91) [[3]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L111-R122) [[4]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L152-R142) [[5]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L173-R163) [[6]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L194-R184) [[7]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L214-R204) [[8]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L236-R226) [[9]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L264-R254) [[10]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L287-R277) [[11]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L310-R300) [[12]](diffhunk://#diff-f864d80bb1225812679094db4d18393ded40d594dd213e74b6182ee2f33c7554L331-R321)