### PR TITLE
fix(Settings): Null reference exception in designer

### DIFF
--- a/StarResonanceDpsAnalysis.WPF/Services/DesignTimeDeviceManagementService.cs
+++ b/StarResonanceDpsAnalysis.WPF/Services/DesignTimeDeviceManagementService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using StarResonanceDpsAnalysis.WPF.Models;
+
+namespace StarResonanceDpsAnalysis.WPF.Services
+{
+    // Pseudocode plan:
+    // - Implement a design-time IDeviceManagementService that returns deterministic, fake data.
+    // - Maintain an in-memory list of mock adapters (name, description) for the designer to display.
+    // - Keep an in-memory reference to the "active" adapter (NetworkAdapterInfo?) when SetActiveNetworkAdapter is called.
+    // - GetNetworkAdaptersAsync: return the mock adapter list.
+    // - GetAutoSelectedNetworkAdapterAsync: return the previously "set" active adapter or null.
+    // - StopActiveCapture: no-op for design-time.
+
+    internal sealed class DesignTimeDeviceManagementService : IDeviceManagementService
+    {
+        private readonly List<(string name, string description)> _mockAdapters =
+        [
+            ("Loopback", "Microsoft KM-TEST Loopback Adapter"),
+            ("Ethernet", "Intel(R) Ethernet Connection I219-V"),
+            ("Wi-Fi", "Realtek 8822CE Wireless LAN 802.11ac PCI-E NIC")
+        ];
+
+        private NetworkAdapterInfo? _activeAdapter;
+
+        public Task<List<(string name, string description)>> GetNetworkAdaptersAsync()
+            => Task.FromResult(_mockAdapters);
+
+        public Task<NetworkAdapterInfo?> GetAutoSelectedNetworkAdapterAsync()
+            => Task.FromResult(_activeAdapter);
+
+        public void SetActiveNetworkAdapter(NetworkAdapterInfo adapter)
+        {
+            _activeAdapter = adapter;
+        }
+
+        public void StopActiveCapture()
+        {
+            // Design-time no-op
+        }
+    }
+}

--- a/StarResonanceDpsAnalysis.WPF/ViewModels/SettingsViewModel.cs
+++ b/StarResonanceDpsAnalysis.WPF/ViewModels/SettingsViewModel.cs
@@ -385,7 +385,7 @@ public enum ShortcutType
 
 public sealed class SettingsDesignTimeViewModel : SettingsViewModel
 {
-    public SettingsDesignTimeViewModel() : base(new DesignConfigManager(), null!)
+    public SettingsDesignTimeViewModel() : base(new DesignConfigManager(), new DesignTimeDeviceManagementService())
     {
         AppConfig = new AppConfig
         {

--- a/StarResonanceDpsAnalysis.WPF/Views/SettingsView.xaml
+++ b/StarResonanceDpsAnalysis.WPF/Views/SettingsView.xaml
@@ -158,7 +158,7 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
-                                    Margin="10"
+                                    Margin="10,0,10,0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Text="{lex:Loc Key={x:Static loc:ResourcesKeys.Settings_NetworkAdapter_Label}}"
@@ -244,7 +244,7 @@
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Text="{lex:Loc {x:Static loc:ResourcesKeys                                     .Settings_Shortcut_TopMost}}" />
+                                    Text="{lex:Loc {x:Static loc:ResourcesKeys.Settings_Shortcut_TopMost}}" />
                                 <TextBox
                                     Grid.Row="1"
                                     Grid.Column="2"


### PR DESCRIPTION
This pull request aims to Fix designer error.

**Design-time services:**

* Added `DesignTimeDeviceManagementService`, a deterministic, in-memory implementation of `IDeviceManagementService` for use in the designer. It provides mock network adapter data, tracks the active adapter, and implements required methods as no-ops or with fake data.
* Updated `SettingsDesignTimeViewModel` to use `DesignTimeDeviceManagementService` and a mock localization manager, ensuring realistic design-time data in the settings view.

**UI improvements:**

* Adjusted the margin of the network adapter label in `SettingsView.xaml` for improved alignment and appearance.