### PR TITLE
Feat/Section Control

### DIFF
--- a/StarResonanceDpsAnalysis.Core/Data/DataStorage.cs
+++ b/StarResonanceDpsAnalysis.Core/Data/DataStorage.cs
@@ -141,6 +141,8 @@ public static class DataStorage
     /// </summary>
     public static event ServerChangedEventHandler? ServerChanged;
 
+    public static event SectionEndedEventHandler? SectionEnded;
+
     /// <summary>
     /// 从文件加载缓存玩家信息
     /// </summary>
@@ -736,5 +738,9 @@ public static class DataStorage
         TriggerPlayerInfoUpdated(uid);
     }
 
+    private static void OnSectionEnded()
+    {
+        SectionEnded?.Invoke();
+    }
     #endregion
 }

--- a/StarResonanceDpsAnalysis.Core/Data/IDataStorage.cs
+++ b/StarResonanceDpsAnalysis.Core/Data/IDataStorage.cs
@@ -23,6 +23,7 @@ public interface IDataStorage : IDisposable
     event DpsDataUpdatedEventHandler? DpsDataUpdated;
     event DataUpdatedEventHandler? DataUpdated;
     event ServerChangedEventHandler? ServerChanged;
+    event SectionEndedEventHandler? SectionEnded;
 
     void LoadPlayerInfoFromFile();
     void SavePlayerInfoToFile();
@@ -75,6 +76,7 @@ public interface IDataStorage : IDisposable
 public delegate void ServerConnectionStateChangedEventHandler(bool serverConnectionState);
 public delegate void PlayerInfoUpdatedEventHandler(PlayerInfo info);
 public delegate void NewSectionCreatedEventHandler();
+public delegate void SectionEndedEventHandler();
 public delegate void BattleLogCreatedEventHandler(BattleLog battleLog);
 public delegate void DpsDataUpdatedEventHandler();
 public delegate void DataUpdatedEventHandler();

--- a/StarResonanceDpsAnalysis.WPF/ViewModels/DpsStatisticsDesignTimeViewModel.cs
+++ b/StarResonanceDpsAnalysis.WPF/ViewModels/DpsStatisticsDesignTimeViewModel.cs
@@ -124,6 +124,7 @@ public sealed class DpsStatisticsDesignTimeViewModel : DpsStatisticsViewModel
         public event DpsDataUpdatedEventHandler? DpsDataUpdated;
         public event DataUpdatedEventHandler? DataUpdated;
         public event ServerChangedEventHandler? ServerChanged;
+        public event SectionEndedEventHandler? SectionEnded;
 #pragma warning restore
 
         public void LoadPlayerInfoFromFile()


### PR DESCRIPTION
This pull request adds a new "SectionEnded" event to the data storage and view model layers, enabling the UI to be notified when a battle section times out (i.e., when combat data is considered ended due to inactivity, but before the data is cleared). The changes improve the separation of concerns between section timeout handling and data clearing, and update the UI logic to reflect section timeouts more accurately. Several flag and event handler updates ensure robust and thread-safe state management.

**Section Timeout & Event Handling Improvements:**

* Introduced a new `SectionEnded` event and its delegate in `IDataStorage`, `DataStorage`, `DataStorageV2`, and `InstantizedDataStorage`, including thread-safe subscription management. This event is raised when a section times out, allowing the UI to respond before data is cleared. [[1]](diffhunk://#diff-ceaf2b59b5056115985fa927fa7bedb9cd876967b755757ca45007cc1a98384eR26) [[2]](diffhunk://#diff-ceaf2b59b5056115985fa927fa7bedb9cd876967b755757ca45007cc1a98384eR79) [[3]](diffhunk://#diff-1244a3f54d4dcc206ef04666d7f4a166efcb259c31ff99fc773fe34e92a6e18fR144-R145) [[4]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bR713) [[5]](diffhunk://#diff-b79719bc20e76e45326ff6938e84034cbcd113b0d218745dcfdc0130a61e202cR28-R30) [[6]](diffhunk://#diff-b79719bc20e76e45326ff6938e84034cbcd113b0d218745dcfdc0130a61e202cR240-R267) [[7]](diffhunk://#diff-d1ad5259886d9c0ed8a37e4e214e74bd0c43a3fb35810b0eb82ea6cd33cd27fbR127)
* Refactored section timeout logic in `DataStorageV2` to use an `_isSectionTimedOut` flag instead of `_timeoutSectionClearedOnce`, and to raise `SectionEnded` on timeout. The section is now cleared only when the next log arrives or a manual clear is triggered. [[1]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL36-R38) [[2]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL251-R259) [[3]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL268-R284) [[4]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL430-R454) [[5]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL454-R477) [[6]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bL468-R491) [[7]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bR614-R619) [[8]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bR631-R636) [[9]](diffhunk://#diff-8cb10aa5e827fce2a03cb1b2188658209674dfdf8c62ecbb329a9508b0b8110bR818-R831)

**ViewModel/UI Updates:**

* The `DpsStatisticsViewModel` now subscribes to the new `SectionEnded` event, uses a `_sectionTimedOut` flag to freeze the duration display when a section times out, and resets this flag appropriately on new section start or data clear. [[1]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR64-R67) [[2]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR168) [[3]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR182-R207) [[4]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR507) [[5]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR520) [[6]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR620-R621) [[7]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fL833-R879) [[8]](diffhunk://#diff-49f8eaa64a94ae693f95b331be0289b446007d0434f9e484bf7b58535c267c7fR897)
* Removed the automatic snapshot-saving logic from `DataStorage_DpsDataUpdated`, as this is now handled by the new event-based approach.

**Minor Fixes:**

* Corrected a log message typo from `DPS` to `DBS` in `UpdateTeamTotalStats`.
* Added a missing using directive in `InstantizedDataStorage.cs`.